### PR TITLE
Fix `Approve MAGIK` button not styled correctly on `Stake` screen

### DIFF
--- a/src/views/Stake/components/Stake.tsx
+++ b/src/views/Stake/components/Stake.tsx
@@ -108,10 +108,11 @@ const Stake: React.FC = () => {
             <StyledCardActions>
               {approveStatus !== ApprovalState.APPROVED ? (
                 <Button
-                  disabled={approveStatus !== ApprovalState.NOT_APPROVED}
-                  className={approveStatus !== ApprovalState.NOT_APPROVED ? 'shinyButton' : 'shinyButtonDisabled'}
-                  style={{marginTop: '20px'}}
-                  onClick={approve}
+                disabled={approveStatus !== ApprovalState.NOT_APPROVED}
+                variant="contained"
+                color="primary"
+                style={{ marginTop: '20px' }}
+                onClick={approve}
                 >
                   Approve MAGIK
                 </Button>


### PR DESCRIPTION
Fixes `Approve MAGIK` button styling on `Stake` screen.

New properties were added to `Approve MAGIK` button
```js
variant="contained"
color="primary"
```